### PR TITLE
Add CommandConfig option to DownloaderCommandArguments

### DIFF
--- a/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
+++ b/DownloaderDataProvider/DownloaderDataProviderArgumentParser.cs
@@ -28,6 +28,7 @@ public static class DownloaderDataProviderArgumentParser
 
     private static readonly List<CommandLineOption> Options = new List<CommandLineOption>
     {
+        new CommandLineOption(DownloaderCommandArguments.CommandConfig, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandDownloaderDataDownloader, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandDataType, CommandOptionType.SingleValue),
         new CommandLineOption(DownloaderCommandArguments.CommandTickers, CommandOptionType.MultipleValue),

--- a/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
+++ b/DownloaderDataProvider/Models/Constants/DownloaderCommandArguments.cs
@@ -18,6 +18,7 @@ namespace QuantConnect.DownloaderDataProvider.Launcher.Models.Constants
 {
     public sealed class DownloaderCommandArguments
     {
+        public const string CommandConfig = "config";
         public const string CommandDownloaderDataDownloader = "data-downloader";
 
         public const string CommandDataType = "data-type";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Added config parameters to DownloaderDataProvider to make it consistent with the parameter list of other tools.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [ ] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
